### PR TITLE
Fix numeric checks

### DIFF
--- a/script.js
+++ b/script.js
@@ -190,8 +190,10 @@ function recalc() {
     const n = +tr.querySelector('.n').value;
     const mean = +tr.querySelector('.mean').value;
     const sd = getSD(tr);
-    tr.querySelector('.sd').textContent = sd ? sd.toFixed(4) : '—';
-    if (n && mean && sd) groups.push({ n, mean, sd });
+    tr.querySelector('.sd').textContent = Number.isFinite(sd) ? sd.toFixed(4) : '—';
+    if (Number.isFinite(n) && Number.isFinite(mean) && Number.isFinite(sd)) {
+      groups.push({ n, mean, sd });
+    }
   });
 
   if (groups.length < 2) {


### PR DESCRIPTION
## Summary
- ensure zero values are not ignored when recalculating stats
- display SD only if it's a valid number

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fa09f18088323b3bb32c94231df98